### PR TITLE
bug: Redis TTL 만료 후 보조 인덱스 삭제 안되는 문제 수정

### DIFF
--- a/src/main/java/com/deview/server/global/auth/filter/JwtFilter.java
+++ b/src/main/java/com/deview/server/global/auth/filter/JwtFilter.java
@@ -26,6 +26,11 @@ public class JwtFilter extends OncePerRequestFilter {
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
 
+        if (request.getRequestURI().equals("/auth/jwt/refresh")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         //Authorization 헤더 검증
         String authorization = request.getHeader("Authorization");
         if (authorization == null) {
@@ -34,7 +39,6 @@ public class JwtFilter extends OncePerRequestFilter {
         }
 
         if (!authorization.startsWith("Bearer ")) {
-            //throw new ServletException("Invalid JWT token");
             throw new JwtException(Status.JWT_INVALID.getMessage());
         }
 

--- a/src/main/java/com/deview/server/global/config/RedisConfig.java
+++ b/src/main/java/com/deview/server/global/config/RedisConfig.java
@@ -7,10 +7,13 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@EnableRedisRepositories(enableKeyspaceEvents = RedisKeyValueAdapter.EnableKeyspaceEvents.ON_STARTUP)
 @Slf4j
 public class RedisConfig {
 
@@ -33,13 +36,6 @@ public class RedisConfig {
         // 일반적인 key:value의 경우 시리얼라이저
         redisTemplate.setKeySerializer(new StringRedisSerializer());
         redisTemplate.setValueSerializer(new StringRedisSerializer());
-
-        // Hash를 사용할 경우 시리얼라이저
-        redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
-
-        // 모든 경우
-        redisTemplate.setDefaultSerializer(new StringRedisSerializer());
 
         return redisTemplate;
     }

--- a/src/main/java/com/deview/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/deview/server/global/config/SecurityConfig.java
@@ -77,7 +77,7 @@ public class SecurityConfig {
                 )
 
                 .addFilterBefore(new JwtFilter(), LogoutFilter.class)
-                .addFilterBefore(new JwtExceptionFilter(), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtExceptionFilter(), JwtFilter.class)
                 .addFilterBefore(loginFilter(), UsernamePasswordAuthenticationFilter.class)
 
                 //cors 설정

--- a/src/main/java/com/deview/server/global/redis/RefreshToken.java
+++ b/src/main/java/com/deview/server/global/redis/RefreshToken.java
@@ -21,13 +21,10 @@ public class RefreshToken {
     @Indexed
     private String jwtRefreshToken;
 
-    @TimeToLive
-    private Long ttl;
 
     @Builder
     public RefreshToken(String jwtRefreshToken, String username) {
         this.jwtRefreshToken = jwtRefreshToken;
         this.username = username;
-        this.ttl = 60*60*24*14L;
     }
 }

--- a/src/main/java/com/deview/server/global/redis/RefreshTokenRepository.java
+++ b/src/main/java/com/deview/server/global/redis/RefreshTokenRepository.java
@@ -4,7 +4,7 @@ import org.springframework.data.repository.CrudRepository;
 
 import java.util.Optional;
 
-public interface RefreshTokenRepository extends CrudRepository<RefreshToken, Long> {
+public interface RefreshTokenRepository extends CrudRepository<RefreshToken, String> {
     Optional<RefreshToken> findRefreshTokenByJwtRefreshToken(String refreshToken);
     boolean existsByJwtRefreshToken(String jwtRefreshToken);
 

--- a/src/main/java/com/deview/server/global/response/Status.java
+++ b/src/main/java/com/deview/server/global/response/Status.java
@@ -34,10 +34,10 @@ public enum Status {
 
 
     //JWT 오류 응답
-    JWT_WRONG_TYPE_TOKEN(HttpStatus.BAD_REQUEST, "JWT400", "JWT 타입이 틀렸습니다."),
-    JWT_EXPIRED_TOKEN(HttpStatus.BAD_REQUEST, "JWT400", "JWT가 만료되었습니다."),
+    JWT_WRONG_TYPE_TOKEN(HttpStatus.UNAUTHORIZED, "JWT401", "JWT 타입이 틀렸습니다."),
+    JWT_EXPIRED_TOKEN(HttpStatus.UNAUTHORIZED, "JWT401", "JWT가 만료되었습니다."),
     JWT_NULL(HttpStatus.UNAUTHORIZED, "JWT401", "JWT가 NULL입니다."),
-    JWT_INVALID(HttpStatus.FORBIDDEN, "JWT403", "JWT가 유효하지 않습니다."),
+    JWT_INVALID(HttpStatus.UNAUTHORIZED, "JWT401", "JWT가 유효하지 않습니다."),
 
     ;
 


### PR DESCRIPTION
# 요약
- #12
-  TTL 만료 후 보조 인덱스 삭제 안되는 문제 

# 변경 사항
- RedisConfig에 EnableRedisRepositories 추가
- RedisTemplate key:value의 경우 시리얼라이저만 유지

# 스크린샷

# 참고사항