### PR TITLE
fix: 상위/하위 카테고리로만 본문 반환으로 수정 

### DIFF
--- a/src/main/java/com/deview/server/domain/study/controller/StudyController.java
+++ b/src/main/java/com/deview/server/domain/study/controller/StudyController.java
@@ -1,10 +1,6 @@
 package com.deview.server.domain.study.controller;
 
-import com.deview.server.domain.study.domain.StudyContent;
-import com.deview.server.domain.study.dto.CategoryItemDto;
-import com.deview.server.domain.study.dto.CategoryListResponseDto;
-import com.deview.server.domain.study.dto.StudyContentRequestDto;
-import com.deview.server.domain.study.dto.StudyContentResponseDto;
+import com.deview.server.domain.study.dto.*;
 import com.deview.server.domain.study.service.StudyService;
 import com.deview.server.global.response.ApiResponse;
 import com.deview.server.global.response.Status;
@@ -22,18 +18,19 @@ public class StudyController {
 
     /**
      * 학습컨텐츠 내용 조회
-     * 상위/하위 카테고리, 제목을 Dto로 받으면 그것을 토대로 Body를 받아와 전부 반환
+     * 상위/하위 카테고리를 Dto로 받으면 그것을 토대로 해당하는 제목과 본문을 전부 반환
      *
      * @param requestDto
-     * @return ApiResponse<StudyContentResponseDto>
+     * @return ApiResponse<StudyContentsResponseDto>
      */
-    @PostMapping("/getBody")
-    public ApiResponse<StudyContentResponseDto> findStudyContent(@Valid @RequestBody StudyContentRequestDto requestDto) {
+    @PostMapping("/contents")
+    public ApiResponse<StudyContentsResponseDto> findStudyContents(@Valid @RequestBody StudyContentRequestDto requestDto) {
 
-        StudyContent contentEntity = studyService.findStudyContentByCriteria(requestDto);
+        List<StudyContentBody> contentBodies = studyService.findStudyContentsByCategory(requestDto);
+        StudyContentsResponseDto responseData = new StudyContentsResponseDto(contentBodies);
 
         return ApiResponse.success(Status.OK.getCode(),
-                Status.OK.getMessage(), StudyContentResponseDto.fromEntity(contentEntity));
+                Status.OK.getMessage(), responseData);
     }
 
     /**

--- a/src/main/java/com/deview/server/domain/study/dto/StudyContentBody.java
+++ b/src/main/java/com/deview/server/domain/study/dto/StudyContentBody.java
@@ -11,26 +11,15 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class StudyContentResponseDto {
-
-    @Schema(description = "상위카테고리", example = "Operating System")
-    private String firstCategory;
-
-    @Schema(description = "하위카테고리", example = "프로세스의 주소 공간")
-    private String secondCategory;
-
+public class StudyContentBody {
     @Schema(description = "제목", example = "프로세스의 주소 공간이란?")
     private String title;
 
     @Schema(description = "내용", example = "프로그램이 CPU에 의해 실행됨 → 프로세스가 생성되고 메모리에 '**프로세스 주소 공간**'이 할당됨...")
     private String body;
 
-    public static StudyContentResponseDto fromEntity(StudyContent entity) {
-        return StudyContentResponseDto.builder()
-                .firstCategory(entity.getFirstCategory())
-                .secondCategory(entity.getSecondCategory())
-                .title(entity.getTitle())
-                .body(entity.getBody())
-                .build();
+    public StudyContentBody(StudyContent studyContent) {
+        this.title = studyContent.getTitle();
+        this.body = studyContent.getBody();
     }
 }

--- a/src/main/java/com/deview/server/domain/study/dto/StudyContentRequestDto.java
+++ b/src/main/java/com/deview/server/domain/study/dto/StudyContentRequestDto.java
@@ -20,10 +20,6 @@ public class StudyContentRequestDto {
     private String firstCategory;
 
     @NotBlank
-    @Schema(description = "하위카테고리", example = "프로세스의 주소 공간")
+    @Schema(description = "하위카테고리", example = "운영체제")
     private String secondCategory;
-
-    @NotBlank
-    @Schema(description = "제목", example = "프로세스의 주소 공간이란?")
-    private String title;
 }

--- a/src/main/java/com/deview/server/domain/study/dto/StudyContentsResponseDto.java
+++ b/src/main/java/com/deview/server/domain/study/dto/StudyContentsResponseDto.java
@@ -1,0 +1,14 @@
+package com.deview.server.domain.study.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class StudyContentsResponseDto {
+    private List<StudyContentBody> contents;
+}

--- a/src/main/java/com/deview/server/domain/study/repository/StudyRepository.java
+++ b/src/main/java/com/deview/server/domain/study/repository/StudyRepository.java
@@ -22,6 +22,8 @@ public interface StudyRepository extends JpaRepository<StudyContent, String> {
             @Param("title") String title
     );
 
+    List<StudyContent> findAllByFirstCategoryAndSecondCategory(String firstCategory, String secondCategory);
+
     /**
      * DB에서 중복을 제거한 firstCategory 목록만 조회
      */

--- a/src/main/java/com/deview/server/domain/study/service/StudyService.java
+++ b/src/main/java/com/deview/server/domain/study/service/StudyService.java
@@ -2,6 +2,7 @@ package com.deview.server.domain.study.service;
 
 import com.deview.server.domain.study.domain.StudyContent;
 import com.deview.server.domain.study.dto.CategoryItemDto;
+import com.deview.server.domain.study.dto.StudyContentBody;
 import com.deview.server.domain.study.dto.StudyContentRequestDto;
 import com.deview.server.domain.study.repository.StudyRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +10,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,16 +20,15 @@ public class StudyService {
     /**
      * 전달하고자 하는 학습 컨텐츠 조회
      */
-    public StudyContent findStudyContentByCriteria(StudyContentRequestDto dto) {
-        String firstCategory = dto.getFirstCategory();
-        String secondCategory = dto.getSecondCategory();
-        String title = dto.getTitle();
+    public List<StudyContentBody> findStudyContentsByCategory(StudyContentRequestDto dto) {
+        List<StudyContent> contents = studyRepository.findAllByFirstCategoryAndSecondCategory(
+                dto.getFirstCategory(),
+                dto.getSecondCategory()
+        );
 
-        return studyRepository.findByCategoriesAndTitle(
-                        firstCategory,
-                        secondCategory,
-                        title
-                ).orElseThrow(() -> new IllegalArgumentException("해당 조건의 학습 컨텐츠를 찾을 수 없습니다."));
+        return contents.stream()
+                .map(StudyContentBody::new)
+                .collect(Collectors.toList());
     }
 
     /**


### PR DESCRIPTION
# 요약
- #26 

# 변경 사항
- 기존 getBody는 상위/하위와 제목까지를 받아 본문을 반환했지만 상위/하위 카테고리만 요청받아 본문들을 반환으로 변경

# 스크린샷
<img width="1277" height="752" alt="image" src="https://github.com/user-attachments/assets/524e421e-d902-4137-bece-2d870293b881" />

# 참고사항


