### PR TITLE
Develop

### DIFF
--- a/src/main/java/com/deview/server/domain/interview/controller/CommunityController.java
+++ b/src/main/java/com/deview/server/domain/interview/controller/CommunityController.java
@@ -1,0 +1,24 @@
+package com.deview.server.domain.interview.controller;
+
+import com.deview.server.domain.interview.dto.community.response.BestQnaListResponseDto;
+import com.deview.server.domain.interview.service.CommunityService;
+import com.deview.server.global.response.ApiResponse;
+import com.deview.server.global.response.Status;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/interview/community")
+public class CommunityController {
+
+    private final CommunityService communityService;
+
+    @GetMapping("/best-qna")
+    public ApiResponse<BestQnaListResponseDto> getBestQna() {
+        BestQnaListResponseDto responseDto = communityService.getBestQna();
+        return ApiResponse.success(Status.OK.getCode(), Status.OK.getMessage(), responseDto);
+    }
+}

--- a/src/main/java/com/deview/server/domain/interview/controller/InterviewChatController.java
+++ b/src/main/java/com/deview/server/domain/interview/controller/InterviewChatController.java
@@ -14,6 +14,7 @@ import com.deview.server.global.response.ApiResponse;
 import com.deview.server.global.response.Status;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
+@Slf4j
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/interview/chat")
@@ -40,6 +42,7 @@ public class InterviewChatController {
 
     @PostMapping("/evaluation")
     public Mono<InterviewEvaluationResponse> evaluate(@RequestBody InterviewEvaluationRequest req) {
+        log.info("Received evaluation request from web client: {}", req);
         return interviewChatService.evaluate(req);
     }
 

--- a/src/main/java/com/deview/server/domain/interview/dto/chat/request/fastapi_request/FastApiEvaluationRequest.java
+++ b/src/main/java/com/deview/server/domain/interview/dto/chat/request/fastapi_request/FastApiEvaluationRequest.java
@@ -16,6 +16,8 @@ import java.util.List;
 @AllArgsConstructor
 @Builder
 public class FastApiEvaluationRequest {
+    @JsonProperty("interviewType")
+    private String interviewType;
     @JsonProperty("conversation")
     private List<Message> conversation;
 }

--- a/src/main/java/com/deview/server/domain/interview/dto/chat/response/InterviewEvaluationResponse.java
+++ b/src/main/java/com/deview/server/domain/interview/dto/chat/response/InterviewEvaluationResponse.java
@@ -14,6 +14,10 @@ import lombok.Setter;
 @AllArgsConstructor
 @Schema(description = "면접 평가 보고서 응답 DTO")
 public class InterviewEvaluationResponse {
+    @JsonProperty("interviewType")
+    @Schema(description = "면접 유형", example = "Operating System")
+    private String interviewType;
+
     @JsonProperty("evaluation_report")
     @Schema(description = "면접 전체 평가 보고서")
     private EvaluationReport evaluationReport;

--- a/src/main/java/com/deview/server/domain/interview/dto/chat/response/interview/InterviewReview.java
+++ b/src/main/java/com/deview/server/domain/interview/dto/chat/response/interview/InterviewReview.java
@@ -9,6 +9,8 @@ import lombok.Setter;
 public class InterviewReview {
     private String company_name;
     private List<Review> reviews;
+    private int jobkorea_count;
+    private int saramin_count;
     private int total_reviews;
 
 }

--- a/src/main/java/com/deview/server/domain/interview/dto/community/response/BestQnaDto.java
+++ b/src/main/java/com/deview/server/domain/interview/dto/community/response/BestQnaDto.java
@@ -1,0 +1,14 @@
+package com.deview.server.domain.interview.dto.community.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BestQnaDto {
+    private String question;
+    private String answer;
+    private String category;
+}

--- a/src/main/java/com/deview/server/domain/interview/dto/community/response/BestQnaListResponseDto.java
+++ b/src/main/java/com/deview/server/domain/interview/dto/community/response/BestQnaListResponseDto.java
@@ -1,0 +1,13 @@
+package com.deview.server.domain.interview.dto.community.response;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class BestQnaListResponseDto {
+    private List<BestQnaDto> bestQnas;
+}

--- a/src/main/java/com/deview/server/domain/interview/repository/InterviewRepository.java
+++ b/src/main/java/com/deview/server/domain/interview/repository/InterviewRepository.java
@@ -37,4 +37,6 @@ public interface InterviewRepository extends JpaRepository<InterviewContent, Str
     List<String> findKeyword(
             @Param("category") String category
     );
+
+    Optional<InterviewContent> findFirstByQuestion(String question);
 }

--- a/src/main/java/com/deview/server/domain/interview/repository/chat/TurnEvaluationRepository.java
+++ b/src/main/java/com/deview/server/domain/interview/repository/chat/TurnEvaluationRepository.java
@@ -1,0 +1,19 @@
+package com.deview.server.domain.interview.repository.chat;
+
+import com.deview.server.domain.interview.domain.chat.TurnEvaluation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface TurnEvaluationRepository extends JpaRepository<TurnEvaluation, Long> {
+    /**
+     * 점수가 특정 기준 이상인 모든 TurnEvaluation을 연관된 ChatReview와 함께 조회합니다.
+     * N+1 쿼리 문제를 방지하기 위해 JOIN FETCH를 사용합니다.
+     * @param score 점수 기준
+     * @return 점수 기준을 만족하는 TurnEvaluation 리스트
+     */
+    @Query("SELECT te FROM TurnEvaluation te JOIN FETCH te.chatReview WHERE te.score >= :score")
+    List<TurnEvaluation> findByScoreGreaterThanEqualWithChatReview(@Param("score") int score);
+}

--- a/src/main/java/com/deview/server/domain/interview/service/CommunityService.java
+++ b/src/main/java/com/deview/server/domain/interview/service/CommunityService.java
@@ -1,0 +1,69 @@
+package com.deview.server.domain.interview.service;
+
+import com.deview.server.domain.interview.domain.chat.TurnEvaluation;
+import com.deview.server.domain.interview.dto.chat.Message;
+import com.deview.server.domain.interview.dto.community.response.BestQnaDto;
+import com.deview.server.domain.interview.dto.community.response.BestQnaListResponseDto;
+import com.deview.server.domain.interview.repository.chat.TurnEvaluationRepository;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CommunityService {
+
+    private final TurnEvaluationRepository turnEvaluationRepository;
+    private final ObjectMapper objectMapper;
+    private static final int SCORE_THRESHOLD = 75;
+
+    public BestQnaListResponseDto getBestQna() {
+        List<TurnEvaluation> highScoringTurns = turnEvaluationRepository.findByScoreGreaterThanEqualWithChatReview(SCORE_THRESHOLD);
+        List<BestQnaDto> bestQnas = new ArrayList<>();
+
+        for (TurnEvaluation turn : highScoringTurns) {
+            try {
+                String messagesJson = turn.getChatReview().getMessages();
+                List<Message> messages = objectMapper.readValue(messagesJson, new TypeReference<>() {});
+
+                int answerIndex = (turn.getTurn() * 2) - 1;
+
+                if (answerIndex >= 0 && answerIndex < messages.size()) {
+                    Message answerMessage = messages.get(answerIndex);
+                    // 해당 메시지가 'user'의 답변인지 확인하여 안정성 확보
+                    if ("user".equals(answerMessage.getRole())) {
+                        String questionText = turn.getQuestion();
+                        String interviewType = turn.getChatReview().getInterviewType();
+                        String category = mapCategory(interviewType); // 카테고리 매핑
+
+                        bestQnas.add(new BestQnaDto(questionText, answerMessage.getContent(), category));
+                    }
+                }
+            } catch (IOException e) {
+                log.error("Failed to parse messages JSON for chatReviewId: {}", turn.getChatReview().getId(), e);
+
+            }
+        }
+        return new BestQnaListResponseDto(bestQnas);
+    }
+
+    private String mapCategory(String interviewType) {
+        return switch (interviewType) {
+            case "Operating System" -> "운영체제" ;
+            case "NetWork" -> "네트워크";
+            case "Database" -> "데이터베이스";
+            case "Computer Architecture" -> "컴퓨터구조";
+            case "SoftWare Engineering" -> "소프트웨어공학";
+            case "Data Structure" -> "자료구조";
+            default -> "기타";
+        };
+    }
+}

--- a/src/main/java/com/deview/server/domain/test/TestController.java
+++ b/src/main/java/com/deview/server/domain/test/TestController.java
@@ -1,9 +1,11 @@
 package com.deview.server.domain.test;
 
+import com.deview.server.global.redis.RefreshTokenRepository;
 import com.deview.server.global.response.ApiResponse;
 import com.deview.server.global.response.Status;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -12,12 +14,21 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/test")
 @Tag(name = "Test", description = "테스트 api")
+@RequiredArgsConstructor
 public class TestController {
+
+    private final RefreshTokenRepository refreshTokenRepository;
 
     @PostMapping()
     @Operation(summary = "테스트 API (POST)", description = "테스트용 POST API입니다.")
     public ApiResponse<?> testPost() {
         return ApiResponse.success(Status.OK.getCode(),Status.OK.getMessage(), "Test POST API is working!");
+    }
+
+    @GetMapping("/allLogout")
+    public ApiResponse<?> allLogout(){
+        refreshTokenRepository.deleteAll();
+        return ApiResponse.success(Status.OK.getCode(), Status.OK.getMessage(), "모든 리프레시 토큰이 삭제되었습니다.");
     }
 
 }


### PR DESCRIPTION
## 릴리스 노트: DeView 서버 v1.1.0

`develop` 브랜치에서 안정화된 DeView 서버 프로젝트를 `main` 브랜치로 병합하여 **v1.1.0 릴리스**를 진행합니다.

---

### 변경 사항 요약

#### 1. 핵심 기능 추가 및 개선 (Interview/Review)

* **Best Q&A 조회 기능 구현**
    * 인터뷰 모범 답변(**Best Q&A**)을 조회하는 API 및 관련 서비스 로직(`DTO` 포함)을 추가. (참고: #47)
* **AI 면접 평가 요청 확장**
    * FastAPI 연동 객체(`FastApiEvaluationRequest`)에 **면접 유형(`interviewType`) 필드**를 추가하여 AI 면접 요청 시 유연성 높임.
* **면접 후기 모델 확장**
    * `InterviewReview` 모델에 **`jobkorea_count` 및 `saramin_count` 필드**를 추가하여 사용자 경험 데이터 기록을 확장. (참고: #47)

#### 2. 보안 및 인프라 개선 (Security/Infra)

* **Redis 초기화 API 추가 (개발 환경용)**
    * 개발 및 테스트 환경에서 Refresh Token 전체 삭제 및 **Redis 초기화**를 수행하는 관리용 API를 추가. (참고: #47)